### PR TITLE
allow typ in header to be optional. 

### DIFF
--- a/API.md
+++ b/API.md
@@ -359,7 +359,7 @@ Generates a token as a string where:
     - `algorithm`- String containing an accepted [algorithm](#Key-algorithms-supported-by-jwt) to be used.  Default is `'HS256'`.
 - `options` - Optional configuration object with the following:
     - `header` - Object to put addtional key/value pairs in the header of the token in addition to `alg` and `typ`.
-    - `typ` Boolean if set to `false` to turn off behavior of creating `typ: 'JWT'` in the header.
+    - `typ` Boolean if set to `false` `typ: 'JWT'` is not included in the header.
     - `now` - Integer as an alternative way to set `iat` claim.  Takes JavaScript style epoch time (with ms).  `iat` claim must not be set and `iat` option must not be `false`. Milliseconds are truncated, not rounded.
     - `ttlSec` -  Integer as an alternative way to set `exp` claim. `exp` is set to be `iat` + `ttlSec`.  `exp` claim must not be set.
     - `iat` - Boolean if set to `false` to turn off default behavior of creating an `iat` claim.

--- a/API.md
+++ b/API.md
@@ -194,7 +194,7 @@ The validate function has a signature of `[async] function (artifacts, request, 
     - `decoded` - An object that contains decoded token.
         - `header` - An object that contain the header information.
             - `alg` - The algorithm used to sign the token.
-            - `typ` - The token type (Should be `'JWT'` if exists) Optional.
+            - `typ` - The token type (should be `'JWT'` if present) (optional).
         - `payload` - An object containing the payload.
         - `signature` - The signature string of the token.
     - `raw` - An object that contains the token that was sent broken out by `header`, `payload`, and `signature`.

--- a/API.md
+++ b/API.md
@@ -194,7 +194,7 @@ The validate function has a signature of `[async] function (artifacts, request, 
     - `decoded` - An object that contains decoded token.
         - `header` - An object that contain the header information.
             - `alg` - The algorithm used to sign the token.
-            - `typ` - The token type (Should be `JWT`).
+            - `typ` - The token type (Should be `'JWT'` if exists) Optional.
         - `payload` - An object containing the payload.
         - `signature` - The signature string of the token.
     - `raw` - An object that contains the token that was sent broken out by `header`, `payload`, and `signature`.
@@ -359,6 +359,7 @@ Generates a token as a string where:
     - `algorithm`- String containing an accepted [algorithm](#Key-algorithms-supported-by-jwt) to be used.  Default is `'HS256'`.
 - `options` - Optional configuration object with the following:
     - `header` - Object to put addtional key/value pairs in the header of the token in addition to `alg` and `typ`.
+    - `typ` Boolean if set to `false` to turn off behavior of creating `typ: 'JWT'` in the header.
     - `now` - Integer as an alternative way to set `iat` claim.  Takes JavaScript style epoch time (with ms).  `iat` claim must not be set and `iat` option must not be `false`. Milliseconds are truncated, not rounded.
     - `ttlSec` -  Integer as an alternative way to set `exp` claim. `exp` is set to be `iat` + `ttlSec`.  `exp` claim must not be set.
     - `iat` - Boolean if set to `false` to turn off default behavior of creating an `iat` claim.

--- a/lib/token.js
+++ b/lib/token.js
@@ -18,6 +18,7 @@ exports.generate = function (payload, secret, options = {}) {
 
     const { key, algorithms } = internals.secret(secret);
     let content = payload;
+    const baseHeader = { alg: algorithms[0] };
 
     const clone = () => {
 
@@ -40,7 +41,11 @@ exports.generate = function (payload, secret, options = {}) {
         content.exp = options.ttlSec + internals.tsSecs(options.now);
     }
 
-    const header = Object.assign({ alg: algorithms[0], typ: 'JWT' }, options.header);
+    if (options.typ !== false) {
+        baseHeader.typ = 'JWT';
+    }
+
+    const header = Object.assign(baseHeader, options.header);
     const value = `${Utils.b64stringify(header)}.${Utils.b64stringify(content, options.encoding || 'utf8')}`;
     const signature = Crypto.generate(value, header.alg, key);
     return `${value}.${signature}`;
@@ -87,7 +92,7 @@ exports.decode = function (token, options = {}) {
         throw internals.error('Invalid token missing header', artifacts);
     }
 
-    if (header.typ !== 'JWT') {
+    if (header.typ && header.typ !== 'JWT') {
         throw internals.error('Token is not a JWT', artifacts);
     }
 

--- a/lib/token.js
+++ b/lib/token.js
@@ -92,7 +92,7 @@ exports.decode = function (token, options = {}) {
         throw internals.error('Invalid token missing header', artifacts);
     }
 
-    if (header.typ && header.typ !== 'JWT') {
+    if (header.typ !== undefined && header.typ !== 'JWT') {
         throw internals.error('Token is not a JWT', artifacts);
     }
 

--- a/test/mock.js
+++ b/test/mock.js
@@ -41,8 +41,14 @@ exports.jwks = async function (options = {}) {
         cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
         cert.setSubject([{ name: 'commonName', value: 'http://example.com' }]);
         cert.sign(Forge.pki.privateKeyFromPem(pair.private));
-        const certPem = Forge.pki.certificateToPem(cert);
-        const certDer = Forge.util.encode64(Forge.asn1.toDer(Forge.pki.certificateToAsn1(Forge.pki.certificateFromPem(certPem))).getBytes());
+        let certDer;
+        if (options.reformat) {
+            certDer = Forge.util.encode64(Forge.asn1.toDer(Forge.pki.certificateToAsn1(Forge.pki.certificateFromPem(Forge.pki.certificateToPem(cert)))).getBytes());
+        }
+        else {
+            certDer = Forge.util.encode64(Forge.asn1.toDer(Forge.pki.certificateToAsn1(cert)).getBytes());
+        }
+
         key.x5c = [certDer];
         key.x5t = key.kid;
     }

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -67,7 +67,7 @@ describe('Plugin', () => {
 
     it('authenticates a request (RSA256 public)', async () => {
 
-        const jwks = await Mock.jwks({ rsa: false, public: true });
+        const jwks = await Mock.jwks({ rsa: false, public: true, reformat: true });
 
         const server = Hapi.server();
         await server.register(Jwt);
@@ -199,7 +199,7 @@ describe('Plugin', () => {
     it('supports multiple strategies', async () => {
 
         const secret = 'some_shared_secret';
-        const jwks = await Mock.jwks();
+        const jwks = await Mock.jwks({ reformat: true });
 
         const server = Hapi.server();
         await server.register(Jwt);

--- a/test/token.js
+++ b/test/token.js
@@ -58,6 +58,20 @@ describe('Token', () => {
         });
     });
 
+    it('creates and verifies a token (no typ)', () => {
+
+        const secret = 'some_shared_secret';
+        const token = Jwt.token.generate({ test: 'ok' }, secret, { typ: false });
+        const artifacts = Jwt.token.decode(token);
+        Jwt.token.verify(artifacts, secret);
+
+        expect(artifacts.decoded).to.equal({
+            header: { alg: 'HS256' },
+            payload: { test: 'ok', iat: artifacts.decoded.payload.iat },
+            signature: artifacts.decoded.signature
+        });
+    });
+
     describe('generate()', () => {
 
         it('creates and verifies a token (custom now)', () => {
@@ -177,7 +191,7 @@ describe('Token', () => {
 
         it('errors on non JWT token', () => {
 
-            const token = `${Jwt.utils.b64stringify({ alg: 'none' })}.${Jwt.utils.b64stringify({}, 'utf8')}.`;
+            const token = `${Jwt.utils.b64stringify({ alg: 'none', typ: 'Not JWT' })}.${Jwt.utils.b64stringify({}, 'utf8')}.`;
             expect(() => Jwt.token.decode(token)).to.throw('Token is not a JWT');
         });
 


### PR DESCRIPTION
Addresses #27 

`typ` is optional based on https://tools.ietf.org/html/rfc7519#section-5.1 