### PR TITLE
Fix serialNumber and remove workarounds

### DIFF
--- a/test/mock.js
+++ b/test/mock.js
@@ -41,14 +41,7 @@ exports.jwks = async function (options = {}) {
         cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
         cert.setSubject([{ name: 'commonName', value: 'http://example.com' }]);
         cert.sign(Forge.pki.privateKeyFromPem(pair.private));
-        let certDer;
-        if (options.reformat) {
-            certDer = Forge.util.encode64(Forge.asn1.toDer(Forge.pki.certificateToAsn1(Forge.pki.certificateFromPem(Forge.pki.certificateToPem(cert)))).getBytes());
-        }
-        else {
-            certDer = Forge.util.encode64(Forge.asn1.toDer(Forge.pki.certificateToAsn1(cert)).getBytes());
-        }
-
+        const certDer = Forge.util.encode64(Forge.asn1.toDer(Forge.pki.certificateToAsn1(cert)).getBytes());
         key.x5c = [certDer];
         key.x5t = key.kid;
     }

--- a/test/mock.js
+++ b/test/mock.js
@@ -35,7 +35,7 @@ exports.jwks = async function (options = {}) {
         const now = new Date();
         const cert = Forge.pki.createCertificate();
         cert.publicKey = Forge.pki.publicKeyFromPem(pair.public);
-        cert.serialNumber = Cryptiles.randomString(5);
+        cert.serialNumber = parseInt(Cryptiles.randomDigits(15)).toString(16);
         cert.validity.notBefore = now;
         cert.validity.notAfter = now;
         cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -65,9 +65,9 @@ describe('Plugin', () => {
         expect(res7.statusCode).to.equal(401);
     });
 
-    it('authenticates a request (RSA256 public)', { retry: true }, async () => {
+    it('authenticates a request (RSA256 public)', async () => {
 
-        const jwks = await Mock.jwks({ rsa: false, public: true, reformat: true });
+        const jwks = await Mock.jwks({ rsa: false, public: true });
 
         const server = Hapi.server();
         await server.register(Jwt);
@@ -196,10 +196,10 @@ describe('Plugin', () => {
         expect(res2.statusCode).to.equal(401);
     });
 
-    it('supports multiple strategies', { retry: true }, async () => {
+    it('supports multiple strategies', async () => {
 
         const secret = 'some_shared_secret';
-        const jwks = await Mock.jwks({ reformat: true });
+        const jwks = await Mock.jwks();
 
         const server = Hapi.server();
         await server.register(Jwt);


### PR DESCRIPTION
According to node-forge the `serialNumber` of an X.509 Cert should be `the hex encoded value of an ASN.1 INTEGER`.

used the code:
 ```javascript
cert.serialNumber = parseInt(Cryptiles.randomDigits(15)).toString(16);
```
to accomplish.  Test no longer are flaky, so previous changes to deal with that are removed.