### PR TITLE
Adding basic type for typescript support

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,185 @@
-import { Plugin } from '@hapi/hapi';
+import { Plugin, ResponseToolkit, Request, ResponseObject } from '@hapi/hapi';
 
-declare const hapiAuthJwt: Plugin<void>;
+declare module '@hapi/hapi' {
+  interface ServerAuth {
+    strategy(name: string, scheme: 'jwt', options?: hapiJwt.Options): void;
+  }
+}
+
+declare namespace hapiJwt {
+  /**
+   * Key algorithms supported.
+   */
+  type SupportedAlgorithm = 'RS256' | 'RS384' | 'RS512' | 'PS256' | 'PS384' | 'PS512' | 'ES256' | 'ES384' | 'ES512' | 'HS256' | 'HS384' | 'HS512';
+  type NoAlgorithm = 'none';
+
+  /**
+   * Key for HMAC and public algorithms.
+   */
+  interface StandardKey {
+    /**
+     * String or binary data that is used for shared secret.
+     */
+    key: string | Buffer;
+    /**
+     * Array of accepted algorithms
+     */
+    algorithms?: SupportedAlgorithm[];
+    /**
+     * String representing the key ID header.
+     */
+    kid?: string;
+  }
+
+  /**
+   * JWKS key
+   */
+  interface JWKSKey {
+    /**
+     * String that defines your json web key set uri.
+     */
+    uri: string;
+    /**
+     * Boolean that determines if TLS flag indicating whether the client should reject a response from a server with invalid certificates. Default is true.
+     */
+    rejectUnauthorized?: boolean
+    /**
+     *Object containing the request headers to send to the uri.
+     */
+    header?: object;
+    /**
+     * Array of accepted algorithms.
+     */
+    algorithms?: SupportedAlgorithm[];
+  }
+
+  type Key = StandardKey | JWKSKey;
+
+  interface VerifyOptions {
+    /**
+     * String or RegExp or array of strings or RegExp that matches the audience of the token. Set to boolean false to not verify aud.
+     */
+    aud: string | string[] | RegExp | RegExp[] | false;
+    /**
+     * String or array of strings that matches the issuer of the token. Set to boolean false to not verify iss.
+     */
+    iss: string | string[] | false;
+    /**
+     * String or array of strings that matches the subject of the token. Set to boolean false to not verify sub.
+     */
+    sub: string | string[] | false;
+    /**
+     * Boolean to determine if the "Not Before" NumericDate of the token should be validated. Default is true.
+     */
+    nbf?: boolean;
+    /**
+     * Boolean to determine if the "Expiration Time" NumericDate of the token should be validated. Default is true.
+     */
+    exp?: boolean;
+    /**
+     * Integer to determine the maximum age of the token in seconds. Default is 0.
+     */
+    maxAgeSec?: number;
+    /**
+     * Integer to adust exp and maxAgeSec to account for server time drift in seconds. Default is 0.
+     */
+    timeSkewSec?: number;
+  }
+
+  interface Artifacts {
+    /**
+     * The complete token that was sent.
+     */
+    token: string;
+    /**
+     * An object that contains decoded token.
+     */
+    decoded: {
+      /**
+       * An object that contain the header information.
+       */
+      header: {
+        /**
+         * The algorithm used to sign the token.
+         */
+        alg: string;
+        /**
+         *  The token type.
+         */
+        typ?: 'JWT';
+      },
+      /**
+       *  An object containing the payload.
+       */
+      payload: object;
+      /**
+       *  The signature string of the token.
+       */
+      signature: string;
+    };
+    /**
+     * An object that contains the token that was sent broken out by header, payload, and signature.
+     */
+    raw?: object;
+    /**
+     * An array of information about key(s) used for authentication.
+     */
+    keys?: StandardKey[];
+  }
+
+  interface ValidationResult {
+    /**
+     * Boolean that should be set to true if additional validation passed, otherwise false.
+     */
+    isValid: boolean;
+    /**
+     * Object passed back to the application in request.auth.credentials.
+     */
+    credentials?: object;
+    /**
+     * Will be used immediately as a takeover response. isValid and credentials are ignored if provided.
+     */
+    response?: ResponseObject;
+  }
+
+  /**
+   * Options passed to `hapi.auth.strategy` when this plugin is used.
+   */
+  interface Options {
+    /**
+     * The key method to be used for jwt verification.
+     */
+    keys: string | string[] | Buffer | Key | Key[] | NoAlgorithm[] | ((param: any) => string);
+    /**
+     * Object to determine how key contents are verified beyond key signature. Set to false to do no verification.
+     */
+    verify: VerifyOptions | false;
+    /**
+     * String the represents the Authentication Scheme. Default is 'Bearer'.
+     */
+    httpAuthScheme?: string;
+    /**
+     * String passed directly to Boom.unauthorized if no custom err is thrown. Defaults to undefined.
+     */
+    unauthorizedAttributes?: string;
+    /**
+     * Function that allows additional validation based on the decoded payload and to put specific credentials in the request object. Can be set to false if no additional validation is needed.
+     *
+     * @param artifacts an object that contains information from the token.
+     * @param request the hapi request object of the request which is being authenticated.
+     * @param h the response toolkit.
+     */
+    validate: ((artifacts: Artifacts, request: Request, h: ResponseToolkit) => Promise<ValidationResult> | never) | false;
+  }
+
+  // To-Do Pending to be defined
+  interface Token {
+  }
+}
+
+declare const hapiAuthJwt: {
+  plugin: Plugin<void>,
+  token: hapiJwt.Token
+};
 
 export = hapiAuthJwt;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -199,7 +199,7 @@ declare namespace hapiJwt {
     /**
      * The "iss" (issuer) claim identifies the principal that issued the JWT. Expressed in a string.
      */
-    iss: string;
+    iss?: string;
     /**
      * The "sub" (subject) claim identifies the principal that is the subject of the JWT. Expressed in a string.
      */
@@ -207,7 +207,7 @@ declare namespace hapiJwt {
     /**
      * The "aud" (audience) claim identifies the recipients that the JWT is intended for. Expressed in a string.
      */
-    aud: string;
+    aud?: string;
     /**
      * The "exp" (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing. Expressed in NumericDate.
      */
@@ -286,11 +286,11 @@ declare namespace hapiJwt {
     /**
      * String or array of strings that matches the JWT ID of the token.
      */
-    jti: string | string[];
+    jti?: string | string[];
     /**
      *String or array of strings that matches the nonce of the token. nonce is used on Open ID for the ID Tokens.
      */
-    nonce: string | string[];
+    nonce?: string | string[];
     /**
      * Integer that represents the "Not Before" NumericDate of the token.
      */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,20 +2,23 @@ import { Plugin, ResponseToolkit, Request, ResponseObject } from '@hapi/hapi';
 
 declare module '@hapi/hapi' {
   interface ServerAuth {
+    /**
+     * Function to define the server authentication strategy to be used.
+     *
+     * @param name string name to define the strategy.
+     * @param scheme jwt for this plugin.
+     * @param options jwt plugin options.
+     */
     strategy(name: string, scheme: 'jwt', options?: hapiJwt.Options): void;
   }
 }
 
 declare namespace hapiJwt {
-  /**
-   * Key algorithms supported.
-   */
+  // Common definitions
+
   type SupportedAlgorithm = 'RS256' | 'RS384' | 'RS512' | 'PS256' | 'PS384' | 'PS512' | 'ES256' | 'ES384' | 'ES512' | 'HS256' | 'HS384' | 'HS512';
   type NoAlgorithm = 'none';
 
-  /**
-   * Key for HMAC and public algorithms.
-   */
   interface StandardKey {
     /**
      * String or binary data that is used for shared secret.
@@ -31,9 +34,6 @@ declare namespace hapiJwt {
     kid?: string;
   }
 
-  /**
-   * JWKS key
-   */
   interface JWKSKey {
     /**
      * String that defines your json web key set uri.
@@ -55,7 +55,68 @@ declare namespace hapiJwt {
 
   type Key = StandardKey | JWKSKey;
 
-  interface VerifyOptions {
+  interface DecodedToken {
+    /**
+     * An object that contain the header information.
+     */
+    header: {
+      /**
+       * The algorithm used to sign the token.
+       */
+      alg: string;
+      /**
+       *  The token type.
+       */
+      typ?: 'JWT';
+    },
+    /**
+     *  An object containing the payload.
+     */
+    payload: object;
+    /**
+     *  The signature string of the token.
+     */
+    signature: string;
+  }
+
+  interface RawToken {
+    /**
+     *  The header of the token.
+     */
+    header: string;
+    /**
+     *  The payload of the token.
+     */
+    payload: string;
+    /**
+     *  The signature of the token.
+     */
+    signature: string;
+  }
+
+  interface Artifacts {
+    /**
+     * The complete token that was sent.
+     */
+    token: string;
+    /**
+     * An object that contains decoded token.
+     */
+    decoded: DecodedToken;
+    /**
+     * An object that contains the token that was sent broken out by header, payload, and signature.
+     */
+    raw: RawToken;
+    /**
+     * An array of information about key(s) used for authentication.
+     */
+    keys?: StandardKey[];
+  }
+
+
+  // Plugin definitions
+
+  interface VerifyKeyOptions {
     /**
      * String or RegExp or array of strings or RegExp that matches the audience of the token. Set to boolean false to not verify aud.
      */
@@ -86,47 +147,6 @@ declare namespace hapiJwt {
     timeSkewSec?: number;
   }
 
-  interface Artifacts {
-    /**
-     * The complete token that was sent.
-     */
-    token: string;
-    /**
-     * An object that contains decoded token.
-     */
-    decoded: {
-      /**
-       * An object that contain the header information.
-       */
-      header: {
-        /**
-         * The algorithm used to sign the token.
-         */
-        alg: string;
-        /**
-         *  The token type.
-         */
-        typ?: 'JWT';
-      },
-      /**
-       *  An object containing the payload.
-       */
-      payload: object;
-      /**
-       *  The signature string of the token.
-       */
-      signature: string;
-    };
-    /**
-     * An object that contains the token that was sent broken out by header, payload, and signature.
-     */
-    raw?: object;
-    /**
-     * An array of information about key(s) used for authentication.
-     */
-    keys?: StandardKey[];
-  }
-
   interface ValidationResult {
     /**
      * Boolean that should be set to true if additional validation passed, otherwise false.
@@ -142,9 +162,7 @@ declare namespace hapiJwt {
     response?: ResponseObject;
   }
 
-  /**
-   * Options passed to `hapi.auth.strategy` when this plugin is used.
-   */
+
   interface Options {
     /**
      * The key method to be used for jwt verification.
@@ -153,7 +171,7 @@ declare namespace hapiJwt {
     /**
      * Object to determine how key contents are verified beyond key signature. Set to false to do no verification.
      */
-    verify: VerifyOptions | false;
+    verify: VerifyKeyOptions | false;
     /**
      * String the represents the Authentication Scheme. Default is 'Bearer'.
      */
@@ -172,14 +190,238 @@ declare namespace hapiJwt {
     validate: ((artifacts: Artifacts, request: Request, h: ResponseToolkit) => Promise<ValidationResult> | never) | false;
   }
 
-  // To-Do Pending to be defined
+
+  // Token definitions
+
+  type AdditionalCredentials = any;
+
+  interface Payload extends AdditionalCredentials {
+    /**
+     * The "iss" (issuer) claim identifies the principal that issued the JWT. Expressed in a string.
+     */
+    iss: string;
+    /**
+     * The "sub" (subject) claim identifies the principal that is the subject of the JWT. Expressed in a string.
+     */
+    sub?: string;
+    /**
+     * The "aud" (audience) claim identifies the recipients that the JWT is intended for. Expressed in a string.
+     */
+    aud: string;
+    /**
+     * The "exp" (expiration time) claim identifies the expiration time on or after which the JWT MUST NOT be accepted for processing. Expressed in NumericDate.
+     */
+    exp?: number;
+    /**
+     * The "nbf" (not before) claim identifies the time before which the JWT MUST NOT be accepted for processing. Expressed in NumericDate.
+     */
+    nbf?: number;
+    /**
+     * The "iat" (issued at) claim identifies the time at which the JWT was issued. Expressed in NumericDate.
+     */
+    iat?: number;
+    /**
+     * The "jti" (JWT ID) claim provides a unique identifier for the JWT. Expressed in a string.
+     */
+    jti?: string;
+    /**
+     * While nonce is not an RFC 7519 Registered Claim, it is used on Open ID for the ID Tokens.
+     */
+    nonce?: string;
+  }
+
+  type Secret = string | Buffer | { key: string | Buffer, algorithm: SupportedAlgorithm | NoAlgorithm};
+
+  interface GenerateOptions {
+    /**
+     * Object to put additional key/value pairs in the header of the token in addition to alg and typ.
+     */
+    header?: object;
+    /**
+     * Boolean if set to false typ: 'JWT' is not included in the header.
+     */
+    typ?: boolean;
+    /**
+     * Integer as an alternative way to set iat claim. Takes JavaScript style epoch time (with ms). iat claim must not be set and iat option must not be false. Milliseconds are truncated, not rounded.
+     */
+    now?: number;
+    /**
+     * Integer as an alternative way to set exp claim. exp is set to be iat + ttlSec. exp claim must not be set.
+     */
+    ttlSec?: number;
+    /**
+     * Boolean if set to false typ: 'JWT' is not included in the header.
+     */
+    iat?: boolean;
+    /**
+     * String to set the encoding use for stringify the payload. Default is utf8.
+     */
+    encoding?: string;
+    /**
+     * Boolean if set to true will decode a valid headless token. Default is false.
+     */
+    headless?: boolean;
+  }
+
+  interface DecodeOptions {
+    /**
+     * Boolean if set to true will decode a valid headless token. Default is false.
+     */
+    headless: boolean;
+  }
+
+  interface VerifyTokenOptions extends TimeOptions {
+    /**
+     * String or RegExp or array of strings or RegExp that matches the audience of the token. Set to boolean false to not verify aud.
+     */
+    aud: string | string[] | RegExp | RegExp[] | false;
+    /**
+     * String or array of strings that matches the issuer of the token. Set to boolean false to not verify iss.
+     */
+    iss: string | string[] | false;
+    /**
+     * String or array of strings that matches the subject of the token. Set to boolean false to not verify sub.
+     */
+    sub: string | string[] | false;
+    /**
+     * String or array of strings that matches the JWT ID of the token.
+     */
+    jti: string | string[];
+    /**
+     *String or array of strings that matches the nonce of the token. nonce is used on Open ID for the ID Tokens.
+     */
+    nonce: string | string[];
+    /**
+     * Integer that represents the "Not Before" NumericDate of the token.
+     */
+    nbf?: number;
+  }
+
+  interface TimeOptions {
+    /**
+     * Integer that represents the current time in JavaScript epoch format (with msecs). When evaluated the msecs are truncated, not rounded. Either this or nowSec need to be defined.
+     */
+    now?: number;
+    /**
+     * Integer that represents the "Expiration Time" NumericDate of the token.
+     */
+    exp?: number;
+    /**
+     * Integer to determine the maximum age of the token in seconds. This is time validation using the "Issued At" NumericDate (iat).
+     */
+    maxAgeSec?: number;
+    /**
+     * Integer to adjust exp and maxAgeSec to account for server time drift in seconds.
+     */
+    timeSkewSec?: number;
+  }
+
   interface Token {
+    /**
+     * Generates a token as a string.
+     *
+     * @param payload object of decoded token in artifacts format.
+     * @param secret object, string or buffer that creates signature.
+     * @param options optional configuration object.
+     */
+    generate: (payload: Payload, secret: Secret, options?: GenerateOptions) => string;
+    /**
+     * Returns an object of a decoded token in the format of artifacts. This does not verify the token, it only decodes it.
+     *
+     * @param token string of encoded token.
+     * @param options optional configuration object.
+     */
+    decode: (token: string, options?: DecodeOptions) => Artifacts | never;
+    /**
+     * A function that will complete if verification passes or throw an error if verification fails.
+     *
+     * @param artifacts object of decoded token in artifacts format.
+     * @param secret object, string or buffer that creates signature.
+     * @param options optional configuration object.
+     */
+    verify: (artifacts: Artifacts, secret: Secret, options?: VerifyTokenOptions) => void | never;
+    /**
+     * A function that will complete if the signature is valid or throw an error if invalid. This does not do verification on the payload. An expired token will not throw an error if the signature is valid.
+     *
+     * @param artifacts object of decoded token in artifacts format.
+     * @param raw object of decoded token in raw format.
+     * @param secret object, string or buffer that creates signature.
+     */
+    verifySignature: (artifacts: Artifacts, secret: Secret) => void | never;
+    /**
+     * A function that will complete if payload verification passes or throw an error if payload verification fails. This does not do verification on the signature.
+     *
+     * @param artifacts object of decoded token in artifacts format..
+     * @param options optional configuration object.
+     */
+    verifyPayload: (artifacts: Artifacts, options?: VerifyTokenOptions) => void | never;
+    /**
+     * A function that will complete if iat and exp verification pass and throw an error if verification fails. This is a subset of verifyPayload for only iat and exp.
+     *
+     * @param artifacts object of decoded token in artifacts format.
+     * @param options optional configuration object.
+     * @param nowSec integer that represents the current time in JavaScript epoch format (with msecs). When evaluated the msecs are truncated, not rounded.
+     */
+    verifyTime: (artifacts: Artifacts, options?: TimeOptions, nowSec?: number) => void | never;
+
+    signature: {
+      /**
+       * Function to generate a signature using a supported algorithm.
+       *
+       * @param value string that represents the signer.
+       * @param algorithm string containing an accepted algorithm to be used.
+       * @param key string that represents the signature.
+       */
+      generate: (value: string, algorithm: SupportedAlgorithm | NoAlgorithm, key: string) => string | never;
+      /**
+       * Function to verify a signature using a supported algorithm.
+       *
+       * @param raw an object that contains the token that was sent broken out by header, payload, and signature.
+       * @param algorithm string containing an accepted algorithm to be used.
+       * @param key string signature to be verify.
+       */
+      verify: (raw: RawToken, algorithm: SupportedAlgorithm | NoAlgorithm, key: string) => boolean | never;
+    }
+  }
+
+
+  // Crypto definitions
+
+  interface Crypto {
+    /**
+     * Function to convert RSA public key to PEM format.
+     *
+     * @param modulusB64 string that represents the modulus (product of two large primes) in base64.
+     * @param exponentB64 string that represents the encryption exponent in base64.
+     */
+    rsaPublicKeyToPEM: (modulusB64: string, exponentB64: string) => string;
+  }
+
+
+  // Utils definitions
+
+  interface Utils {
+    /**
+     * Function that converts an object to a string in base64.
+     *
+     * @param obj object to be converted.
+     */
+    b64stringify: (obj: object) => string;
+    /**
+     * Function that converts a number to hexadecimal string.
+     *
+     * @param number number to be converted.
+     */
+    toHex: (number: number) => string;
   }
 }
 
+
 declare const hapiAuthJwt: {
   plugin: Plugin<void>,
-  token: hapiJwt.Token
+  token: hapiJwt.Token,
+  crypto: hapiJwt.Crypto,
+  utils: hapiJwt.Utils
 };
 
 export = hapiAuthJwt;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,5 @@
+import { Plugin } from '@hapi/hapi';
+
+declare const hapiAuthJwt: Plugin<void>;
+
+export = hapiAuthJwt;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@types/hapi__hapi": "20.x.x",
         "node-forge": "0.10.x",
         "node-rsa": "1.x.x",
-        "typescript": "^4.1.3"
+        "typescript": "4.x.x"
     },
     "scripts": {
         "test": "lab -a @hapi/code -t 100 -L -Y -m 10000",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "version": "2.0.1",
     "repository": "git://github.com/hapijs/jwt",
     "main": "lib/index.js",
+    "types": "lib/index.d.ts",
     "files": [
         "lib"
     ],
@@ -30,7 +31,8 @@
         "@hapi/hapi": "20.x.x",
         "@hapi/lab": "24.x.x",
         "node-forge": "0.10.x",
-        "node-rsa": "1.x.x"
+        "node-rsa": "1.x.x",
+        "typescript": "^4.1.3"
     },
     "scripts": {
         "test": "lab -a @hapi/code -t 100 -L -m 10000",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@hapi/code": "8.x.x",
         "@hapi/hapi": "20.x.x",
         "@hapi/lab": "24.x.x",
-        "@types/hapi__hapi": "^20.0.3",
+        "@types/hapi__hapi": "20.x.x",
         "node-forge": "0.10.x",
         "node-rsa": "1.x.x",
         "typescript": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -30,12 +30,13 @@
         "@hapi/code": "8.x.x",
         "@hapi/hapi": "20.x.x",
         "@hapi/lab": "24.x.x",
+        "@types/hapi__hapi": "^20.0.3",
         "node-forge": "0.10.x",
         "node-rsa": "1.x.x",
         "typescript": "^4.1.3"
     },
     "scripts": {
-        "test": "lab -a @hapi/code -t 100 -L -m 10000",
+        "test": "lab -a @hapi/code -t 100 -L -Y -m 10000",
         "test-cov-html": "lab -a @hapi/code -r html -o coverage.html"
     },
     "license": "BSD-3-Clause"

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,10 @@
+
+import * as Jwt from '..';
+import { Plugin } from '@hapi/hapi';
+import * as Lab from '@hapi/lab';
+
+const { expect } = Lab.types;
+
+// Jwt
+
+expect.type<Plugin<void>>(Jwt);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,8 +1,7 @@
-
 import * as Jwt from '..';
 import { Plugin } from '@hapi/hapi';
 import * as Lab from '@hapi/lab';
 
 const { expect } = Lab.types;
 
-expect.type<Plugin<void>>(Jwt);
+expect.type<Plugin<void>>(Jwt.plugin);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,7 +1,58 @@
-import * as Jwt from '..';
 import { Plugin } from '@hapi/hapi';
 import * as Lab from '@hapi/lab';
 
+import * as Jwt from '..';
+
 const { expect } = Lab.types;
 
+
+// Plugin definitions
+
 expect.type<Plugin<void>>(Jwt.plugin);
+
+
+// Token definitions
+
+const token = Jwt.token.generate(
+  {
+    aud: 'urn:audience:test',
+    iss: 'urn:issuer:test',
+    user: 'some_user_name',
+    group: 'hapi_community'
+  },
+  {
+    key: 'some_shared_secret',
+    algorithm: 'HS512'
+  },
+  {
+    ttlSec: 14400 // 4 hours
+  }
+);
+expect.type<string>(token);
+
+const decodedToken = Jwt.token.decode(token);
+expect.type<string>(decodedToken.token);
+
+expect.type<void>(Jwt.token.verify(decodedToken, 'some_shared_secret'));
+
+expect.type<void>(Jwt.token.verifySignature(decodedToken, 'some_shared_secret'));
+
+expect.type<void>(Jwt.token.verifyPayload(decodedToken));
+
+expect.type<void>(Jwt.token.verifyTime(decodedToken));
+
+expect.type<string>(Jwt.token.signature.generate(decodedToken.token, 'HS512', 'some_shared_secret'));
+
+expect.type<boolean>(Jwt.token.signature.verify(decodedToken.raw, 'HS512', 'some_shared_secret'));
+
+
+// Crypto definitions
+
+expect.type<string>(Jwt.crypto.rsaPublicKeyToPEM('00:aa:18:ab:a4:3b:50:de:ef:38:59:8f:af:87:d2','65537'));
+
+
+// Utils definitions
+
+expect.type<string>(Jwt.utils.toHex(2020));
+
+expect.type<string>(Jwt.utils.b64stringify({ foo: 'bar'}));

--- a/test/index.ts
+++ b/test/index.ts
@@ -5,6 +5,4 @@ import * as Lab from '@hapi/lab';
 
 const { expect } = Lab.types;
 
-// Jwt
-
 expect.type<Plugin<void>>(Jwt);


### PR DESCRIPTION
### Context

Considering the issue https://github.com/hapijs/jwt/issues/30 to add type support, I have started the work defining the very very basic type required to avoid ts linter error when you import the plugin in your Hapi solution.

I know that it is still pending the definition of the rest of modules, but at least it allows the basic use with typescript support.

As a reference, I have used [type definition for Hapi cookie plugin](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/hapi__cookie/index.d.ts)

### Work done

- [x] Plugin type definition for the main module 
- [x] Skeleton for testing types and coverage test for the ones added in the PR

### Alternatives

We can define the types into [Definitely Typed project](https://github.com/DefinitelyTyped/DefinitelyTyped) but I have considered that if we give support internally, it will always be the best option in terms of maintainability, and users will not have to install additional dependencies. Anyway, no worries if you consider that use Definitely Typed here is a better option 😉  it is just a matter of moving it