### PR TITLE
add support for reading token from cookie

### DIFF
--- a/API.md
+++ b/API.md
@@ -254,9 +254,9 @@ validate: (artifacts, request, h) => {
 
  - `headerName` - Tells the jwt plugin to read the token from the header specified. Default is `authorization` 
 
- ##### cookieName
+##### cookieName
 
- - `cookieName` - Tells the jwt plugin to read the token from the cookie specified. Note that the plugin does not allow you to read from cookie and header at the same time, either read from a header or from a cookie. If you want to read from cookie and header you must use multiple strategies with in which one will have `headerName` config and other will have `cookieName` config Default is `undefined` 
+ - `cookieName` - Tells the jwt plugin to read the token from the cookie specified. Note that the plugin does not allow you to read from cookie and header at the same time, either read from a header or from a cookie. If you want to read from cookie and header you must use multiple strategies with in which one will have `headerName` config and other will have `cookieName` config. Defaults to `undefined`.
 
 
 ## token

--- a/API.md
+++ b/API.md
@@ -252,7 +252,7 @@ validate: (artifacts, request, h) => {
 
 ##### headerName
 
- - `headerName` - Tells the jwt plugin to read the token from the header specified. Default is `authorization` 
+ - `headerName` - Tells the jwt plugin to read the token from the header specified. Default is `'authorization'`.
 
 ##### cookieName
 

--- a/API.md
+++ b/API.md
@@ -249,6 +249,16 @@ validate: (artifacts, request, h) => {
     };
 }
 ```
+
+##### headerName
+
+ - `headerName` - Tells the jwt plugin to read the token from the header specified. Default is `authorization` 
+
+ ##### cookieName
+
+ - `cookieName` - Tells the jwt plugin to read the token from the cookie specified. Note that the plugin does not allow you to read from cookie and header at the same time, either read from a header or from a cookie. If you want to read from cookie and header you must use multiple strategies with in which one will have `headerName` config and other will have `cookieName` config Default is `undefined` 
+
+
 ## token
 
 In addition to creating an auth strategy, the `jwt` module can be used directly even if you aren't using hapi, to run token based functions.

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,7 +8,7 @@ const Joi = require('joi');
 const Crypto = require('./crypto');
 const Keys = require('./keys');
 const Token = require('./token');
-const { validHttpTokenSchema } = require('./utils');
+const Utils = require('./utils');
 
 
 const internals = {};
@@ -71,7 +71,7 @@ internals.schema.strategy = Joi.object({
             generateTimeout: 2 * 60 * 1000                      // 2 minutes
         }),
 
-    cookieName: validHttpTokenSchema
+    cookieName: Utils.validHttpTokenSchema
         .optional()
         .messages({
             'string.pattern.base':
@@ -81,7 +81,7 @@ internals.schema.strategy = Joi.object({
     headerName: Joi.any().when('cookieName', {
         is: Joi.exist(),
         then: Joi.string().forbidden().messages({ 'any.unknown': 'headerName not allowed when cookieName is specified' }),
-        otherwise: validHttpTokenSchema.optional()
+        otherwise: Utils.validHttpTokenSchema.optional()
             .default('authorization')
             .messages({
                 'string.pattern.base': 'Header name must be a valid header name following https://tools.ietf.org/html/rfc7230#section-3.2.6'

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -70,11 +70,19 @@ internals.schema.strategy = Joi.object({
             generateTimeout: 2 * 60 * 1000                      // 2 minutes
         }),
 
-    cookieName: Joi.alternatives()
-        .try(Joi.string(), Joi.boolean()).default('token').optional(),
+    cookieName: Joi.string().allow(false)
+        .pattern(/^(([\w]+)(-|_)?([\d\w]+))+$/)
+        .messages({
+            'string.pattern.base': 'Cookie name cannot start or end with special characters. Valid characters in cookie name are _, -, numbers and alphabets'
+        }),
 
-    headerName: Joi.alternatives()
-        .try(Joi.string(), Joi.boolean()).default('authorization').optional(),
+    // Refer for header name pattern reference https://github.com/nodejs/node/blob/7ef069e483e015a803660125cdbfa81ddfa0357b/lib/_http_common.js#L203
+
+    headerName: Joi.string().allow(false)
+        .pattern(/^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/)
+        .messages({
+            'string.pattern.base': 'Header name must be a valid header name following https://tools.ietf.org/html/rfc7230#section-3.2.6'
+        }),
 
     headless: [Joi.string(), Joi.object({ alg: Joi.string().valid(...Keys.supportedAlgorithms).required(), typ: Joi.valid('JWT') }).unknown()],
 
@@ -122,7 +130,7 @@ internals.schema.strategy = Joi.object({
     })
         .when('.validate', { is: Joi.not(false), then: Joi.allow(false) })
         .required()
-});
+}).xor('cookieName', 'headerName');
 
 
 internals.implementation = function (server, options) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -8,6 +8,7 @@ const Joi = require('joi');
 const Crypto = require('./crypto');
 const Keys = require('./keys');
 const Token = require('./token');
+const { validHttpTokenSchema } = require('./utils');
 
 
 const internals = {};
@@ -70,19 +71,22 @@ internals.schema.strategy = Joi.object({
             generateTimeout: 2 * 60 * 1000                      // 2 minutes
         }),
 
-    cookieName: Joi.string().allow(false)
-        .pattern(/^(([\w]+)(-|_)?([\d\w]+))+$/)
+    cookieName: validHttpTokenSchema
+        .optional()
         .messages({
-            'string.pattern.base': 'Cookie name cannot start or end with special characters. Valid characters in cookie name are _, -, numbers and alphabets'
+            'string.pattern.base':
+                'Cookie name cannot start or end with special characters. Valid characters in cookie name are _, -, numbers and alphabets'
         }),
 
-    // Refer for header name pattern reference https://github.com/nodejs/node/blob/7ef069e483e015a803660125cdbfa81ddfa0357b/lib/_http_common.js#L203
-
-    headerName: Joi.string().allow(false)
-        .pattern(/^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/)
-        .messages({
-            'string.pattern.base': 'Header name must be a valid header name following https://tools.ietf.org/html/rfc7230#section-3.2.6'
-        }),
+    headerName: Joi.any().when('cookieName', {
+        is: Joi.exist(),
+        then: Joi.string().forbidden().messages({ 'any.unknown': 'headerName not allowed when cookieName is specified' }),
+        otherwise: validHttpTokenSchema.optional()
+            .default('authorization')
+            .messages({
+                'string.pattern.base': 'Header name must be a valid header name following https://tools.ietf.org/html/rfc7230#section-3.2.6'
+            })
+    }),
 
     headless: [Joi.string(), Joi.object({ alg: Joi.string().valid(...Keys.supportedAlgorithms).required(), typ: Joi.valid('JWT') }).unknown()],
 
@@ -130,7 +134,7 @@ internals.schema.strategy = Joi.object({
     })
         .when('.validate', { is: Joi.not(false), then: Joi.allow(false) })
         .required()
-}).xor('cookieName', 'headerName');
+});
 
 
 internals.implementation = function (server, options) {
@@ -244,16 +248,13 @@ internals.token = function (request, settings, missing, unauthorized) {
 
     // Read the authentication token from the source depending upon the setting
 
-    let authorization;
+    let authorization = null;
 
     if (settings.headerName) {
         authorization = request.headers[settings.headerName];
     }
-    else if (settings.cookieName) {
-        authorization = request.state[settings.cookieName];
-    }
     else {
-        authorization = null;
+        authorization = request.state[settings.cookieName];
     }
 
     if (!authorization) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -115,7 +115,13 @@ internals.schema.strategy = Joi.object({
         timeSkewSec: Joi.number().integer().min(0).default(0)
     })
         .when('.validate', { is: Joi.not(false), then: Joi.allow(false) })
-        .required()
+        .required(),
+
+    headerName: Joi.alternatives()
+        .try(Joi.string(), Joi.boolean()).default('authorization').optional(),
+
+    cookieName: Joi.alternatives()
+        .try(Joi.string(), Joi.boolean()).default('token').optional()
 });
 
 
@@ -226,28 +232,58 @@ internals.implementation = function (server, options) {
 };
 
 
+const getTokenFromCookie = (cookieHeader, cookieName) => {
+
+    if (!(cookieHeader || cookieName)) {
+        return null;
+    }
+
+    const cookies = cookieHeader.split(/;(\s+)?/);
+
+    // find the cookie with the cookie name given in the settings
+    for (let i = 0; i < cookies.length; i += 1) {
+        const [name, value] = cookies[i].split('=');
+
+        if (name === cookieName) {
+            return value;
+        }
+    }
+
+    return '';
+};
+
+
 internals.token = function (request, settings, missing, unauthorized) {
 
-    const authorization = request.headers.authorization;
+    // if both the headerName and cookieName are given false then we should fallback to
+    // authorization header as the default
+    const authorization =
+        request.headers[settings.headerName]
+            || getTokenFromCookie(request.headers.cookie, settings.cookieName)
+            || request.headers.authorization;
+
     if (!authorization) {
         throw missing;
     }
 
-    // Parse authorization header
+    // authorization header will be like <Scheme> <Token>
+    if (settings.headerName) {
+        const parts = authorization.split(/\s+/);
+        if (parts[0].toLowerCase() !== settings.httpAuthScheme.toLowerCase()) {
+            throw missing;
+        }
 
-    const parts = authorization.split(/\s+/);
-    if (parts[0].toLowerCase() !== settings.httpAuthScheme.toLowerCase()) {
-        throw missing;
+        if (parts.length !== 2) {
+            throw unauthorized('Bad HTTP authentication header format');
+        }
+
+        const token = parts[1];
+        if (!token) {
+            throw missing;
+        }
+
+        return token;
     }
 
-    if (parts.length !== 2) {
-        throw unauthorized('Bad HTTP authentication header format');
-    }
-
-    const token = parts[1];
-    if (!token) {
-        throw missing;
-    }
-
-    return token;
+    return authorization;
 };

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -70,6 +70,12 @@ internals.schema.strategy = Joi.object({
             generateTimeout: 2 * 60 * 1000                      // 2 minutes
         }),
 
+    cookieName: Joi.alternatives()
+        .try(Joi.string(), Joi.boolean()).default('token').optional(),
+
+    headerName: Joi.alternatives()
+        .try(Joi.string(), Joi.boolean()).default('authorization').optional(),
+
     headless: [Joi.string(), Joi.object({ alg: Joi.string().valid(...Keys.supportedAlgorithms).required(), typ: Joi.valid('JWT') }).unknown()],
 
     httpAuthScheme: Joi.string().default('Bearer'),
@@ -115,13 +121,7 @@ internals.schema.strategy = Joi.object({
         timeSkewSec: Joi.number().integer().min(0).default(0)
     })
         .when('.validate', { is: Joi.not(false), then: Joi.allow(false) })
-        .required(),
-
-    headerName: Joi.alternatives()
-        .try(Joi.string(), Joi.boolean()).default('authorization').optional(),
-
-    cookieName: Joi.alternatives()
-        .try(Joi.string(), Joi.boolean()).default('token').optional()
+        .required()
 });
 
 
@@ -232,41 +232,21 @@ internals.implementation = function (server, options) {
 };
 
 
-const getTokenFromCookie = (cookieHeader, cookieName) => {
-
-    if (!(cookieHeader || cookieName)) {
-        return null;
-    }
-
-    const cookies = cookieHeader.split(/;(\s+)?/);
-
-    // find the cookie with the cookie name given in the settings
-    for (let i = 0; i < cookies.length; i += 1) {
-        const [name, value] = cookies[i].split('=');
-
-        if (name === cookieName) {
-            return value;
-        }
-    }
-
-    return '';
-};
-
-
 internals.token = function (request, settings, missing, unauthorized) {
 
-    // if both the headerName and cookieName are given false then we should fallback to
+    // If both the headerName and cookieName are given false then we should fallback to
     // authorization header as the default
+
     const authorization =
         request.headers[settings.headerName]
-            || getTokenFromCookie(request.headers.cookie, settings.cookieName)
-            || request.headers.authorization;
+            || request.state[settings.cookieName];
 
     if (!authorization) {
         throw missing;
     }
 
-    // authorization header will be like <Scheme> <Token>
+    // Authorization header will be like <Scheme> <Token>
+
     if (settings.headerName) {
         const parts = authorization.split(/\s+/);
         if (parts[0].toLowerCase() !== settings.httpAuthScheme.toLowerCase()) {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -242,12 +242,19 @@ internals.implementation = function (server, options) {
 
 internals.token = function (request, settings, missing, unauthorized) {
 
-    // If both the headerName and cookieName are given false then we should fallback to
-    // authorization header as the default
+    // Read the authentication token from the source depending upon the setting
 
-    const authorization =
-        request.headers[settings.headerName]
-            || request.state[settings.cookieName];
+    let authorization;
+
+    if (settings.headerName) {
+        authorization = request.headers[settings.headerName];
+    }
+    else if (settings.cookieName) {
+        authorization = request.state[settings.cookieName];
+    }
+    else {
+        authorization = null;
+    }
 
     if (!authorization) {
         throw missing;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const B64 = require('@hapi/b64');
+const Joi = require('joi');
 
 
 const internals = {};
@@ -21,3 +22,7 @@ exports.toHex = function (number) {
 
     return nstr;
 };
+
+// Refer for header name pattern reference https://github.com/nodejs/node/blob/7ef069e483e015a803660125cdbfa81ddfa0357b/lib/_http_common.js#L203
+
+exports.validHttpTokenSchema = Joi.string().pattern(/^[\^_`a-zA-Z\-0-9!#$%&'*+.|~]+$/);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@hapi/code": "8.x.x",
     "@hapi/eslint-plugin": "*",
     "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x",
+    "@hapi/lab": "^25.0.1",
     "node-forge": "0.10.x",
     "node-rsa": "1.x.x"
   },

--- a/test/keys.js
+++ b/test/keys.js
@@ -233,7 +233,7 @@ describe('Keys', () => {
 
         it('reports remote source missing payload error', async () => {
 
-            const jwks = Hapi.server();
+            const jwks = Hapi.server({ host: 'localhost' });
             const path = '/.well-known/jwks.json';
             jwks.route({ method: 'GET', path, handler: () => '' });
             await jwks.start();
@@ -260,7 +260,7 @@ describe('Keys', () => {
         it('reports remote source invalid payload error', async () => {
 
             for (const payload of [{}, { keys: 123 }, { keys: [] }]) {
-                const jwks = Hapi.server();
+                const jwks = Hapi.server({ host: 'localhost' });
                 const path = '/.well-known/jwks.json';
                 jwks.route({ method: 'GET', path, handler: () => payload });
                 await jwks.start();

--- a/test/mock.js
+++ b/test/mock.js
@@ -12,7 +12,7 @@ const internals = {};
 
 exports.jwks = async function (options = {}) {
 
-    const server = Hapi.server();
+    const server = Hapi.server({ host: 'localhost' });
     const path = '/.well-known/jwks.json';
     server.route({ method: 'GET', path, handler: () => server.app.jwks });
     await server.start();

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -495,4 +495,161 @@ describe('Plugin', () => {
 
         await jwks.server.stop();
     });
+
+    it('uses authorization as headerName when cookieName or headerName is not specified in config', async () => {
+
+        const secret = 'some_shared_secret';
+
+        const server = Hapi.server();
+
+        server.register(Jwt);
+
+        server.auth.strategy('jwt', 'jwt', {
+            keys: secret,
+            verify: {
+                aud: 'urn:audience:test',
+                iss: 'urn:issuer:test',
+                sub: false
+            },
+            validate: (artifacts, request, h) => {
+
+                return { isValid: true, credentials: { user: artifacts.decoded.payload.user } };
+            }
+        });
+
+        server.auth.default('jwt');
+
+        server.route({ path: '/', method: 'GET', handler: (request) => request.auth.credentials.user });
+
+        const token = Jwt.token.generate({ user: 'steve', aud: 'urn:audience:test', iss: 'urn:issuer:test' }, secret, { header: { kid: 'some' } });
+        const res = await server.inject({ url: '/', headers: { authorization: `Bearer ${token}` } });
+        expect(res.result).to.equal('steve');
+    });
+
+    it('reads token from cookie specified in cookieName and authenticates', async () => {
+
+        const secret = 'some_shared_secret';
+
+        const server = Hapi.server();
+
+        server.register(Jwt);
+
+        const cookieName = 'random-cookie';
+
+        server.auth.strategy('jwt', 'jwt', {
+            keys: secret,
+            verify: {
+                aud: 'urn:audience:test',
+                iss: 'urn:issuer:test',
+                sub: false
+            },
+            validate: (artifacts, request, h) => {
+
+                return { isValid: true, credentials: { user: artifacts.decoded.payload.user } };
+            },
+            cookieName
+        });
+
+        server.auth.default('jwt');
+
+        server.route({ path: '/', method: 'GET', handler: (request) => request.auth.credentials.user });
+
+        const token = Jwt.token.generate({ user: 'steve', aud: 'urn:audience:test', iss: 'urn:issuer:test' }, secret, { header: { kid: 'some' } });
+        const res = await server.inject({ url: '/', headers: { cookie: `${cookieName}=${token}` } });
+
+        expect(res.result).to.equal('steve');
+    });
+
+    it('reads token from header specified by headerName and authenticates', async () => {
+
+        const secret = 'some_shared_secret';
+
+        const server = Hapi.server();
+
+        server.register(Jwt);
+
+        const headerName = 'random-header';
+
+        server.auth.strategy('jwt', 'jwt', {
+            keys: secret,
+            verify: {
+                aud: 'urn:audience:test',
+                iss: 'urn:issuer:test',
+                sub: false
+            },
+            validate: (artifacts, request, h) => {
+
+                return { isValid: true, credentials: { user: artifacts.decoded.payload.user } };
+            },
+            headerName
+        });
+
+        server.auth.default('jwt');
+
+        server.route({ path: '/', method: 'GET', handler: (request) => request.auth.credentials.user });
+
+        const token = Jwt.token.generate({ user: 'steve', aud: 'urn:audience:test', iss: 'urn:issuer:test' }, secret, { header: { kid: 'some' } });
+        const res = await server.inject({ url: '/', headers: { [headerName]: `Bearer ${token}` } });
+
+        expect(res.result).to.equal('steve');
+    });
+
+    it('errors when token is not present at headerName or cookieName', async () => {
+
+        const secret = 'some_shared_secret';
+
+        const server = Hapi.server();
+
+        server.register(Jwt);
+
+        const headerName = 'random-header';
+        const cookieName = 'random-cookie';
+
+        server.auth.strategy('jwt-header', 'jwt', {
+            keys: secret,
+            verify: {
+                aud: 'urn:audience:test',
+                iss: 'urn:issuer:test',
+                sub: false
+            },
+            validate: (artifacts, request, h) => {
+
+                return { isValid: true, credentials: { user: artifacts.decoded.payload.user } };
+            },
+            headerName
+        });
+
+        server.auth.strategy('jwt-cookie', 'jwt', {
+            keys: secret,
+            verify: {
+                aud: 'urn:audience:test',
+                iss: 'urn:issuer:test',
+                sub: false
+            },
+            validate: (artifacts, request, h) => {
+
+                return { isValid: true, credentials: { user: artifacts.decoded.payload.user } };
+            },
+            cookieName
+        });
+
+        server.route({
+            path: '/',
+            method: 'GET',
+            options: {
+                auth: {
+                    strategies: ['jwt-header', 'jwt-cookie']
+                }
+            },
+            handler: (request) => request.auth.credentials.user
+        });
+
+        const token = Jwt.token.generate({ user: 'steve', aud: 'urn:audience:test', iss: 'urn:issuer:test' }, secret, { header: { kid: 'some' } });
+
+        const resWithHeader = await server.inject({ url: '/', headers: { 'another-header-name': `Bearer ${token}` } });
+        expect(resWithHeader.statusCode).to.equal(401);
+
+        const resWithCookie = await server.inject({ url: '/', headers: { 'cookie': `another-cookie=${token}` } });
+        expect(resWithCookie.statusCode).to.equal(401);
+    });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,7 +3,6 @@
 const Code = require('@hapi/code');
 const Jwt = require('..');
 const Lab = require('@hapi/lab');
-const { validHttpTokenSchema } = require('../lib/utils');
 
 
 const internals = {};
@@ -32,7 +31,7 @@ describe('Utils', () => {
             const validHttpTokens = ['cookie-name', 'cookie_name', '_cookie-name', 'cookie__name', 'cookie--name', '__--cookie--name__--'];
 
             for (const token of validHttpTokens) {
-                expect(validHttpTokenSchema.validate(token).error).to.not.exist();
+                expect(Jwt.utils.validHttpTokenSchema.validate(token).error).to.not.exist();
             }
         });
 
@@ -44,7 +43,7 @@ describe('Utils', () => {
             ];
 
             for (const token of invalidHttpTokens) {
-                expect(validHttpTokenSchema.validate(token).error).to.exist();
+                expect(Jwt.utils.validHttpTokenSchema.validate(token).error).to.exist();
             }
         });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -40,7 +40,7 @@ describe('Utils', () => {
 
             const invalidHttpTokens = [
                 'a)b', 'a(b', 'a<b', 'a>b', 'a@b', 'a,b', 'a;b', 'a:b', 'a\\b',
-                'a/b', 'a[b', 'a]b', 'a?b', 'a=b', '{', '}'
+                'a/b', 'a[b', 'a]b', 'a?b', 'a=b', 'q{a', 'b}n'
             ];
 
             for (const token of invalidHttpTokens) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -36,7 +36,7 @@ describe('Utils', () => {
             }
         });
 
-        it('errors for invalid cookie names', () => {
+        it('errors for invalid http tokens', () => {
 
             const invalidHttpTokens = [
                 'a)b', 'a(b', 'a<b', 'a>b', 'a@b', 'a,b', 'a;b', 'a:b', 'a\\b',

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,6 +3,7 @@
 const Code = require('@hapi/code');
 const Jwt = require('..');
 const Lab = require('@hapi/lab');
+const { validHttpTokenSchema } = require('../lib/utils');
 
 
 const internals = {};
@@ -21,6 +22,30 @@ describe('Utils', () => {
             expect(Jwt.utils.toHex(1)).to.equal('01');
             expect(Jwt.utils.toHex(100001)).to.equal('0186a1');
             expect(Jwt.utils.toHex(4040404)).to.equal('3da6d4');
+        });
+    });
+
+    describe('validHttpTokenSchema', () => {
+
+        it('allows valid http tokens', () => {
+
+            const validHttpTokens = ['cookie-name', 'cookie_name', '_cookie-name', 'cookie__name', 'cookie--name', '__--cookie--name__--'];
+
+            for (const token of validHttpTokens) {
+                expect(validHttpTokenSchema.validate(token).error).to.not.exist();
+            }
+        });
+
+        it('errors for invalid cookie names', () => {
+
+            const invalidHttpTokens = [
+                'a)b', 'a(b', 'a<b', 'a>b', 'a@b', 'a,b', 'a;b', 'a:b', 'a\\b',
+                'a/b', 'a[b', 'a]b', 'a?b', 'a=b', '{', '}'
+            ];
+
+            for (const token of invalidHttpTokens) {
+                expect(validHttpTokenSchema.validate(token).error).to.exist();
+            }
         });
     });
 });


### PR DESCRIPTION
This PR aims to fix #28 by adding two fields in settings to set the header name and cookie name. Then while reading the token instead of hardcoding the header name or cookie name we read from what is specified in the settings.

Let me know if there is any changes that should be done in the PR

Thank you 