### PR TITLE
Use request time instead of verification time

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -168,7 +168,7 @@ internals.implementation = function (server, options) {
 
             if (settings.verify) {
                 try {
-                    Token.verifyPayload(result.artifacts, settings.verify);
+                    Token.verifyPayload(result.artifacts, { ...settings.verify, now: request.info.received });
                 }
                 catch (err) {
                     return h.unauthenticated(unauthorized(err.message), result);


### PR DESCRIPTION
Hi,

This resolves an issue we have in production, where a perfectly valid token at the moment of the request becomes invalid when it reaches the verification step.
For example, on a super slow upload, by the time the file is fully streamed, the token can become expired.

I think it is safe to assume that the time comparison should be based on the request arrival and not when the token is processed, but should it be considered a breaking change?