### PR TITLE
Replace joi dependency with @hapi/joi for ecosystem consistency

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,7 +3,7 @@
 const Boom = require('@hapi/boom');
 const CatboxObject = require('@hapi/catbox-object');
 const Hoek = require('@hapi/hoek');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 const Crypto = require('./crypto');
 const Keys = require('./keys');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const B64 = require('@hapi/b64');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 
 
 const internals = {};

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "@hapi/catbox-object": "^3.0.0",
     "@hapi/cryptiles": "^6.0.0",
     "@hapi/hoek": "^10.0.0",
+    "@hapi/joi": "^17.1.1",
     "@hapi/wreck": "^18.0.0",
-    "ecdsa-sig-formatter": "^1.0.0",
-    "joi": "^17.2.1"
+    "ecdsa-sig-formatter": "^1.0.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.0",


### PR DESCRIPTION
Otherwise schema conflicts are caused when using @hapi/joi due to its incompatibility with joi.